### PR TITLE
Changed Desktop Only to false

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,5 @@
 	"description": "Enables relative line numbers in editor mode",
 	"author": "Nadav Spiegelman",
 	"authorUrl": "https://nadav.is",
-	"isDesktopOnly": true
+	"isDesktopOnly": false
 }


### PR DESCRIPTION
The plugin works just fine on my iPad, so I just disabled `"isDesktopOnly"` to be able to use it there as well.
If there are any issues on that regard that I am not aware of, please let me know.