### PR TITLE
Remove dependency and fix folding behavior

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -1,0 +1,92 @@
+import { Extension } from "@codemirror/state";
+import { EditorView, ViewUpdate, gutter, lineNumbers, GutterMarker } from "@codemirror/view";
+import { Compartment, EditorState } from "@codemirror/state";
+import {foldedRanges} from "@codemirror/language"
+
+let relativeLineNumberGutter = new Compartment();
+
+class Marker extends GutterMarker {
+  /** The text to render in gutter */
+  text: string;
+
+  constructor(text: string) {
+    super();
+    this.text = text;
+  }
+
+  toDOM() {
+    return document.createTextNode(this.text);
+  }
+}
+
+const absoluteLineNumberGutter = gutter({
+  lineMarker: (view, line) => {
+    const lineNo = view.state.doc.lineAt(line.from).number;
+    const absoluteLineNo = new Marker(lineNo.toString());
+    const cursorLine = view.state.doc.lineAt(
+      view.state.selection.asSingle().ranges[0].to
+    ).number;
+
+    if (lineNo === cursorLine) {
+      return absoluteLineNo;
+    }
+
+    return null;
+  },
+  initialSpacer: () => {
+    const spacer = new Marker("0");
+    return spacer;
+  },
+});
+
+function relativeLineNumbers(lineNo: number, state: EditorState) {
+  if (lineNo > state.doc.lines) {
+    return " ";
+  }
+  const cursorLine = state.doc.lineAt(
+    state.selection.asSingle().ranges[0].to
+  ).number;
+  
+
+  const start = Math.min( state.doc.line(lineNo).from, 
+                          state.selection.asSingle().ranges[0].to)
+
+  const stop = Math.max( state.doc.line(lineNo).from, 
+                          state.selection.asSingle().ranges[0].to)
+
+  const folds = foldedRanges(state)
+  let foldedCount = 0
+  folds.between(start, stop, (from, to) => {
+    let rangeStart = state.doc.lineAt(from).number
+    let rangeStop = state.doc.lineAt(to).number
+    foldedCount += rangeStop - rangeStart
+  })
+
+  if (lineNo === cursorLine) {
+    return " ";
+  } else {
+    return (Math.abs(cursorLine - lineNo)-foldedCount).toString();
+  }
+}
+// This shows the numbers in the gutter
+const showLineNumbers = relativeLineNumberGutter.of(
+  lineNumbers({ formatNumber: relativeLineNumbers })
+);
+
+// This ensures the numbers update
+// when selection (cursorActivity) happens
+const lineNumbersUpdateListener = EditorView.updateListener.of(
+  (viewUpdate: ViewUpdate) => {
+    if (viewUpdate.selectionSet) {
+      viewUpdate.view.dispatch({
+        effects: relativeLineNumberGutter.reconfigure(
+          lineNumbers({ formatNumber: relativeLineNumbers })
+        ),
+      });
+    }
+  }
+);
+
+export function lineNumbersRelative(): Extension {
+  return [absoluteLineNumberGutter, showLineNumbers, lineNumbersUpdateListener];
+}

--- a/main.ts
+++ b/main.ts
@@ -1,5 +1,5 @@
 import { Plugin } from "obsidian";
-import { lineNumbersRelative } from "codemirror-line-numbers-relative";
+import { lineNumbersRelative } from "./extension";
 
 export default class RelativeLineNumbers extends Plugin {
   enabled: boolean;

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "esbuild": "0.13.12",
     "obsidian": "^0.12.17",
     "tslib": "2.3.1",
-    "typescript": "4.4.4"
-  },
-  "dependencies": {
-    "codemirror-line-numbers-relative": "^0.19.3-beta.4"
+    "typescript": "4.4.4",
+    "@codemirror/state": "^6.2.0",
+    "@codemirror/view": "^6.2.0",
+    "@codemirror/language": "^6.6.0"
   }
 }


### PR DESCRIPTION
Currently the plugin doesn't handle folds consistently (see #14). This PR changes behavior so that displayed line numbers factor in folds, making navigation easier. It also pulls the CM6 extension into this repo and eliminates the dependency on `codemirror-linenumbers-relative`, which hadn't been updated in 2 years and called deprecated methods (see #13).