### PR TITLE
Fix varying line number widths

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -12,6 +12,7 @@ class Marker extends GutterMarker {
   constructor(text: string) {
     super();
     this.text = text;
+    this.elementClass = "relative-line-numbers-mono";
   }
 
   toDOM() {
@@ -19,10 +20,19 @@ class Marker extends GutterMarker {
   }
 }
 
+function linesCharLength(state: EditorState): number {
+  /**
+   * Get the character length of the number of lines in the document
+   * Example: 100 lines -> 3 characters
+   */
+  return state.doc.lines.toString().length;
+}
+
 const absoluteLineNumberGutter = gutter({
   lineMarker: (view, line) => {
     const lineNo = view.state.doc.lineAt(line.from).number;
-    const absoluteLineNo = new Marker(lineNo.toString());
+    const charLength = linesCharLength(view.state);
+    const absoluteLineNo = new Marker(lineNo.toString().padStart(charLength, " "));
     const cursorLine = view.state.doc.lineAt(
       view.state.selection.asSingle().ranges[0].to
     ).number;
@@ -40,8 +50,10 @@ const absoluteLineNumberGutter = gutter({
 });
 
 function relativeLineNumbers(lineNo: number, state: EditorState) {
+  const charLength = linesCharLength(state);
+  const blank = " ".padStart(charLength, " ");
   if (lineNo > state.doc.lines) {
-    return " ";
+    return blank;
   }
   const cursorLine = state.doc.lineAt(
     state.selection.asSingle().ranges[0].to
@@ -63,9 +75,9 @@ function relativeLineNumbers(lineNo: number, state: EditorState) {
   })
 
   if (lineNo === cursorLine) {
-    return " ";
+    return blank;
   } else {
-    return (Math.abs(cursorLine - lineNo)-foldedCount).toString();
+    return (Math.abs(cursorLine - lineNo) - foldedCount).toString().padStart(charLength, " ");
   }
 }
 // This shows the numbers in the gutter

--- a/extension.ts
+++ b/extension.ts
@@ -43,8 +43,8 @@ const absoluteLineNumberGutter = gutter({
 
     return null;
   },
-  initialSpacer: () => {
-    const spacer = new Marker("0");
+  initialSpacer: (view: EditorView) => {
+    const spacer = new Marker("0".repeat(linesCharLength(view.state)));
     return spacer;
   },
 });

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,10 @@
+.relative-line-numbers-mono {
+  font-family: monospace;
+  white-space: pre;
+}
+
+.cm-lineNumbers {
+  font-family: monospace;
+  white-space: pre;
+  min-width: 25px; /* prevent relative line numbers from shifting on files with ~10-20 lines */
+}


### PR DESCRIPTION
Fixes a bug (#10) that occurs when the cursor moves and the character width of the line number changes. Sets the character width equal to the character width of the number of lines in the document. Forces a monospace font for the gutter.

![bsidian-relative-linenumbers-diffiwdth-bug-fixed](https://user-images.githubusercontent.com/5504267/222768011-093d6f28-11ea-4f13-acdf-83421749e718.gif)
