### PR TITLE
Improve Performance

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -169,9 +169,8 @@ const lineNumbersUpdateListener = EditorView.updateListener.of(
     // If there have not been any scheduled updates for some time, we dispatch
     // the update instantly to reduce perceivable waittime. Should the
     // following call happen soon, then we prepare for a burst of updates and
-    // add the delay. An exception is made when there has not been an update
-    // for a long time, so the user can see some incremental changes.
-    const dispatchInstantly = currentTime - lastUpdate >= 2 * minimumDispatchTime || currentTime - lastDispatchedUpdate > maximumDispatchTime;
+    // add the delay.
+    const dispatchInstantly = currentTime - lastUpdate >= 2 * minimumDispatchTime;
     lastUpdate = currentTime;
 
     if (dispatchInstantly) {  

--- a/extension.ts
+++ b/extension.ts
@@ -3,9 +3,8 @@ import { EditorView, ViewUpdate, gutter, lineNumbers, GutterMarker } from "@code
 import { Compartment, EditorState } from "@codemirror/state";
 import {foldedRanges} from "@codemirror/language"
 
-// Adjustable timing parameters
-const minimumDispatchTime = 50;
-const maximumDispatchTime = 500;
+// Adjustable timing parameter
+const dispatchTime = 50;
 
 // Calculation
 let relativeLineNumberGutter = new Compartment();
@@ -170,7 +169,7 @@ const lineNumbersUpdateListener = EditorView.updateListener.of(
     // the update instantly to reduce perceivable waittime. Should the
     // following call happen soon, then we prepare for a burst of updates and
     // add the delay.
-    const dispatchInstantly = currentTime - lastUpdate >= 2 * minimumDispatchTime;
+    const dispatchInstantly = currentTime - lastUpdate >= 2 * dispatchTime;
     lastUpdate = currentTime;
 
     if (dispatchInstantly) {  
@@ -183,7 +182,7 @@ const lineNumbersUpdateListener = EditorView.updateListener.of(
       setTimeout(() => {
         // If a newer update has been queued, cancel this update.
         if (currentTime == lastUpdate) dispatchUpdate(currentTime, viewUpdate);
-      }, minimumDispatchTime);
+      }, dispatchTime);
     }
   }
 );

--- a/extension.ts
+++ b/extension.ts
@@ -6,6 +6,15 @@ import {foldedRanges} from "@codemirror/language"
 let relativeLineNumberGutter = new Compartment();
 let cursorLine: number = -1;
 let selectionTo: number = -1;
+let charLength: number = 0;
+let blank: string = "";
+
+let lastUpdate: number = 0
+
+const lastUpdateForLine = new Map<number, string>();
+const lastNumberForLine = new Map<number, string>();
+
+let linesUpdated = new Set<number>();
 
 class Marker extends GutterMarker {
   /** The text to render in gutter */
@@ -51,19 +60,35 @@ const absoluteLineNumberGutter = gutter({
   },
 });
 
-function relativeLineNumbers(lineNo: number, state: EditorState) {
-  const charLength = linesCharLength(state);
-  const blank = " ".padStart(charLength, " ");
-  if (lineNo > state.doc.lines) {
+function curryRelativeLineNumbers(updateTime: number) {
+  return (lineNo: number, state: EditorState) => relativeLineNumbers(lineNo, state, updateTime);
+}
+
+function relativeLineNumbers(lineNo: number, state: EditorState, updateTime: number) {
+  // Ignore the first line update, since two are always triggered.
+  const currentUpdateIdentificator = createUpdateIdentificator(state);
+  if (!lastUpdateForLine.has(lineNo) || lastUpdateForLine.get(lineNo) != currentUpdateIdentificator) {
+    lastUpdateForLine.set(lineNo, currentUpdateIdentificator);
+    return lastNumberForLine.get(lineNo) || blank;
+  }
+
+  // Do not act on old updates
+  if (updateTime < lastUpdate) {
+    return lastNumberForLine.get(lineNo) || blank;
+  }
+
+  // Blank if out of range or current line
+  if (lineNo > state.doc.lines || lineNo == cursorLine) {
+    lastNumberForLine.set(lineNo, blank);
     return blank;
   }
 
   if (selectionTo == -1) {
     selectionTo = state.selection.asSingle().ranges[0].to;
-    const newCursorLine = state.doc.lineAt(selectionTo).number;
   }
   const selectionFrom = state.doc.line(lineNo).from;
 
+  // Determine the scope of the line numbers
   let start, stop;
   if (selectionTo > selectionFrom) {
     start = selectionFrom;
@@ -73,6 +98,7 @@ function relativeLineNumbers(lineNo: number, state: EditorState) {
     selectionTo = selectionFrom;
   }
 
+  // Count the number of lines that are folded between the start and stop
   const folds = foldedRanges(state)
   let foldedCount = 0
   folds.between(start, stop, (from, to) => {
@@ -81,36 +107,62 @@ function relativeLineNumbers(lineNo: number, state: EditorState) {
     foldedCount += rangeStop - rangeStart
   })
 
-  if (lineNo === cursorLine) {
-    return blank;
-  } else {
-    return (Math.abs(cursorLine - lineNo) - foldedCount).toString().padStart(charLength, " ");
-  }
+  const lineNumberResult = (Math.abs(cursorLine - lineNo) - foldedCount).toString().padStart(charLength, " ");
+  lastNumberForLine.set(lineNo, lineNumberResult);
+  return lineNumberResult;
 }
 
 // This shows the numbers in the gutter
 const showLineNumbers = relativeLineNumberGutter.of(
-  lineNumbers({ formatNumber: relativeLineNumbers })
+  lineNumbers({ formatNumber: curryRelativeLineNumbers(0) })
 );
+
+function createUpdateIdentificator(state: EditorState): string {
+  return [
+    JSON.stringify(state.selection.toJSON(), null, 2),
+    state.doc.length
+  ].join('-');
+}
 
 // This ensures the numbers update
 // when selection (cursorActivity) happens
 const lineNumbersUpdateListener = EditorView.updateListener.of(
   (viewUpdate: ViewUpdate) => {
     if (viewUpdate.selectionSet) {
-      
+      const currentTime = (new Date()).getMilliseconds();
+      lastUpdate = currentTime;
+      linesUpdated = new Set<number>();
+
       const state = viewUpdate.state;
+
+      charLength = linesCharLength(state);
+      blank = " ".padStart(charLength, " ");
+
       selectionTo = state.selection.asSingle().ranges[0].to;
       const newCursorLine = state.doc.lineAt(selectionTo).number;
 
+      // If we have not changed the line, do not update the line numbers.
       if (newCursorLine == cursorLine) return;
       cursorLine = newCursorLine;
 
-      viewUpdate.view.dispatch({
-        effects: relativeLineNumberGutter.reconfigure(
-          lineNumbers({ formatNumber: relativeLineNumbers })
-        ),
-      });
+      // We add a delay to dispatching updates to avoid issuing updates too
+      // often, like when scrolling or holding down movement keys.
+      // If this is not done, then the rendering thread is slowed down resulting
+      // in visible lag.
+      // 
+      // TODO: consider making the delay adaptive. It should increase if the
+      // updates are cancelled most of the time and decrease if they are not.
+      setTimeout(() => { 
+        // Don't act on old updates
+        if (currentTime != lastUpdate) {
+          return;
+        }
+        viewUpdate.view.dispatch({
+          effects: relativeLineNumberGutter.reconfigure(
+            lineNumbers({ formatNumber: curryRelativeLineNumbers(currentTime) })
+          ),
+        });
+      }, 50);
     }
   }
 );

--- a/extension.ts
+++ b/extension.ts
@@ -149,14 +149,6 @@ function dispatchUpdate(currentTime: number, viewUpdate: ViewUpdate) {
 // when selection (cursorActivity) happens
 const lineNumbersUpdateListener = EditorView.updateListener.of(
   (viewUpdate: ViewUpdate) => {
-    // TODO: this initial if check prevents updates that should happen in a certain edge case.
-    // Reproduction steps (not necessarily minimal):
-    // - Use vim bindings with this plugin.
-    // - Have a line with an admonition/quote block i.e. a line beginning with "> ".
-    // - Enter insert mode at the end of this line.
-    // - Press the enter key.
-    // A new line will be created, but the line numbers will not update.
-    // This bug exists in the versions before the performance patch that included this comment.
     if (viewUpdate.selectionSet) {
       // Position calculations
       const state = viewUpdate.state;


### PR DESCRIPTION
Addresses poor performance as reported in #12 

**Improved**
- Don't update line numbers when the active line does not change.
   > This fully resolves all lag caused by this plugin when moving left or right on a single line or when typing.
- Don't recalculate the same values for every single line.
   > A lot of math was being done for every line that always resulted in the same values, like calculating which line the cursor is currently on. Computations like these are now done only whenever necessary.
- Prevent double updates.
   > Every view update actually triggers twice. This was previously passed onto the line numbers, which all recalculated their value twice - once more than actually needed. Now, an update will only be delegated to rendering, if something has actually changed.
- Limit the amount of dispatched updates.
   > Add a limit to the amount of line number updates issued. Currently, at most one update can happen every 50ms. To do this, almost all updates are delayed by 50ms after first being observed. If a new update happens during that time, the previous one is cancelled. This is true except for one case:
   >
   > If there haven't been any updates for the last 100ms, then no delay is added. This is to ensure that the recalculation remains responsive to the user, e.g., if you simply move down by one line, you will not see any delays.
   >
   > This change particularly targets "burst" updates, like holding down an up/down arrow key or j/k with vim bindings.

**Future Considerations**
The calculation of 'foldedRange' is particularly slow. Simplified, every line iterates over the entire text in a note. A more efficient data structure, like a sparse table, could improve the performance. The idea would be to perform the expensive creation of such a data structure once for a dispatched update, following which, the individual lines would only have to access the results. In that way, the complexity of O(n²) regarding the amount of lines could reduced to at least O(n log n), if not O(n).