### PR TITLE
fix: prevent duplicated addition in nested folded lines

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -68,10 +68,16 @@ function relativeLineNumbers(lineNo: number, state: EditorState) {
 
   const folds = foldedRanges(state)
   let foldedCount = 0
-  folds.between(start, stop, (from, to) => {
+  let foldedIntervals: [number, number][] = [];
+  folds.between(start, stop - 1, (from, to) => {
     let rangeStart = state.doc.lineAt(from).number
     let rangeStop = state.doc.lineAt(to).number
+    let withinExistingInterval = foldedIntervals.some(([intervalStart, intervalStop]) =>
+      intervalStart < rangeStart && rangeStart < intervalStop
+    );
+    if (withinExistingInterval) return;
     foldedCount += rangeStop - rangeStart
+    foldedIntervals.push([rangeStart, rangeStop]);
   })
 
   if (lineNo === cursorLine) {


### PR DESCRIPTION
### Problem

The value for relative line numbers would break if there exists nested folded lines

<img width="711" alt="Screenshot 2025-03-20 at 10 30 00 PM" src="https://github.com/user-attachments/assets/53e3724b-1490-4773-abd7-652ecacae0a8" />

The expanded form is as follows

<img width="711" alt="Screenshot 2025-03-20 at 10 29 43 PM" src="https://github.com/user-attachments/assets/b682d154-0839-4e88-8af7-c813f6c474cc" />

The following two gif files display the original and the modified relative line numbers respectively

[original.gif](https://github.com/user-attachments/assets/11f32e5d-50ee-40f8-96e5-9f66e6b3b763)
[modified.gif](https://github.com/user-attachments/assets/a592a4c5-cffc-4604-aad2-95aecd0455cd)

(The modified version still suffers from erroneous relative line numbers if the cursor is at the end of line in insert mode)

---

### Implementation

A naive solution which increases `foldedCount` only if the current interval is not covered by any larger interval is implemented
(The solution assumes that larger coverage intervals are checked before all the possible smaller nested intervals)